### PR TITLE
Minor chart enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Vault Sidecar Injector
 
-## Release v5.1.0 - 2019-12-xx
+## Release v5.1.0 - 2019-12-09
 
 - [VSI #14](https://github.com/Talend/vault-sidecar-injector/pull/14) - Minor updates to Helm chart and documentation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Vault Sidecar Injector
 
-## Release v5.0.1 - 2019-12-xx
+## Release v5.1.0 - 2019-12-xx
 
 - [VSI #14](https://github.com/Talend/vault-sidecar-injector/pull/14) - Minor updates to Helm chart and documentation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Vault Sidecar Injector
 
+## Release v5.0.1 - 2019-12-xx
+
+- [VSI #14](https://github.com/Talend/vault-sidecar-injector/pull/14) - Minor updates to Helm chart and documentation.
+
 ## Release v5.0.0 - 2019-12-06
 
 - [VSI #13](https://github.com/Talend/vault-sidecar-injector/pull/13) - New [Proxy](https://github.com/Talend/vault-sidecar-injector/blob/master/doc/Discovering-Vault-Sidecar-Injector-Proxy.md) mode. Injected Vault Agent sidecar can act as a local proxy forwarding application requests to Vault server.

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
-VERSION:=5.0.0
+RELEASE_VERSION:=5.0.1	# Release version
+VSI_VERSION:=5.0.0		# Version of VSI binary and image
 
 OWNER:=Talend
 REPO:=vault-sidecar-injector
 TARGET:=target/vaultinjector-webhook
 SRC:=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-# Inject version into code at build time
-LDFLAGS=-ldflags "-X=main.VERSION=$(VERSION)"
+# Inject VSI version into code at build time
+LDFLAGS=-ldflags "-X=main.VERSION=$(VSI_VERSION)"
 
 .SILENT: ;  	# No need for @
 .ONESHELL: ; 	# Single shell for a target (required to properly use all of our local variables)
@@ -40,18 +41,18 @@ package:
 
 image:
 	echo "Build image from sources ..."
-	docker build -t talend/vault-sidecar-injector:${VERSION} .
+	docker build -t talend/vault-sidecar-injector:${VSI_VERSION} .
 
 image-from-build: build
 	echo "Build image from local build ..."
-	docker build -f Dockerfile.local -t talend/vault-sidecar-injector:${VERSION} .
+	docker build -f Dockerfile.local -t talend/vault-sidecar-injector:${VSI_VERSION} .
 
 release: image-from-build package
 	cd target
 	echo "Releasing artifacts ..."
 	read -p "- Github user name to use for release: " username
 	echo "- Creating release"
-	id=$$(curl -u $$username -s -X POST "https://api.github.com/repos/${OWNER}/${REPO}/releases" -d '{"tag_name": "v'${VERSION}'", "name": "v'${VERSION}'", "draft": true, "body": ""}' | jq '.id')
+	id=$$(curl -u $$username -s -X POST "https://api.github.com/repos/${OWNER}/${REPO}/releases" -d '{"tag_name": "v'${RELEASE_VERSION}'", "name": "v'${RELEASE_VERSION}'", "draft": true, "body": ""}' | jq '.id')
 	if [ "$$?" -ne 0 ]; then \
 		echo "Unable to create release"; \
 		echo $$id; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RELEASE_VERSION:=5.0.1	# Release version
+RELEASE_VERSION:=5.1.0	# Release version
 VSI_VERSION:=5.0.0		# Version of VSI binary and image
 
 OWNER:=Talend

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ This command removes all the Kubernetes components associated with the chart and
 
 ## Configuration
 
-The following tables lists the configurable parameters of the `Vault Sidecar Injector` chart and their default values.
+The following table lists the configurable parameters of the `Vault Sidecar Injector` chart and their default values.
 
 | Parameter    | Description          | Default                                                         |
 |:-------------|:---------------------|:----------------------------------------------------------------|
@@ -868,7 +868,7 @@ The following tables lists the configurable parameters of the `Vault Sidecar Inj
 | service.name                                    | Service name            | talend-vault-sidecar-injector                                   |
 | service.prefixWithHelmRelease                   | Service name to be prefixed with Helm release name                                       | false                                                           |
 | service.type                        | Kubernetes service type: ClusterIP, NodePort, LoadBalancer, ExternalName  | ClusterIP    |
-| vault.addr                                      | Address of Vault server    | https://vault:8200       |
+| vault.addr                          | Address of Vault server    | `null` - To be provided at deployment time (e.g.: https://vault:8200)   |
 | vault.authMethods.approle.path      | Path defined for AppRole Auth Method            | approle |
 | vault.authMethods.approle.roleid_filename    | Filename for role id    | approle_roleid   |
 | vault.authMethods.approle.secretid_filename  | Filename for secret id  | approle_secretid |

--- a/README.md
+++ b/README.md
@@ -828,6 +828,7 @@ The following table lists the configurable parameters of the `Vault Sidecar Inje
 | image.pullPolicy   | Pull policy for docker image: IfNotPresent or Always       | IfNotPresent           |
 | image.serviceNameLabel   | Service Name. Must match label com.talend.service     | talend-vault-sidecar-injector      |
 | image.tag  | Version/tag of the docker image     | 5.0.0      |
+| imageRegistry  | Image registry |   |
 | injectconfig.jobbabysitter.image.path   | Docker image path | everpeace/curl-jq |
 | injectconfig.jobbabysitter.image.pullPolicy | Pull policy for docker image: IfNotPresent or Always | IfNotPresent |
 | injectconfig.jobbabysitter.image.tag   | Version/tag of the docker image  | latest |
@@ -858,6 +859,7 @@ The following table lists the configurable parameters of the `Vault Sidecar Inje
 | probes.readiness.periodSeconds                  | How often (in seconds) to perform the probe       | 20   |
 | probes.readiness.successThreshold      | Minimum consecutive successes for the probe to be considered successful after having failed  | 1  |
 | probes.readiness.timeoutSecon          | Number of seconds after which the probe times out  | 5   |
+| registryKey         | Name of Kubernetes secret for image registry                        |  |
 | replicaCount                        | Number of replicas | 3    |
 | resources.limits.cpu                | CPU resource limits                             | 250m         |
 | resources.limits.memory             | Memory resource limits                          | 256Mi        |

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: vault-sidecar-injector
 description: A Helm chart for Talend Vault Sidecar Injector (OSS)
-version: 3.0.0
+version: 3.1.0
 icon: https://www.talend.com/wp-content/uploads/talend-logo.svg
 keywords:
    - Talend

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -64,38 +64,31 @@ heritage: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
-Define the docker registry key.
-*/}}
-{{- define "talend-vault-sidecar-injector.registryKey" -}}
-{{- .registryKey | default "" -}}
-{{- end -}}
-
-{{/*
 Define the docker image (image.path:image.tag).
 */}}
 {{- define "talend-vault-sidecar-injector.image" -}}
-{{- printf "%s%s:%s" .imageRegistry .image.path (default "latest" .image.tag) -}}
+{{- printf "%s%s:%s" (default "" .imageRegistry) .image.path (default "latest" .image.tag) -}}
 {{- end -}}
 
 {{/*
 Define the docker image for Job Babysitter sidecar container (image.path:image.tag).
 */}}
 {{- define "talend-vault-sidecar-injector.injectconfig.jobbabysitter.image" -}}
-{{- printf "%s%s:%s" .imageRegistry .injectconfig.jobbabysitter.image.path (default "latest" .injectconfig.jobbabysitter.image.tag) -}}
+{{- printf "%s%s:%s" (default "" .imageRegistry) .injectconfig.jobbabysitter.image.path (default "latest" .injectconfig.jobbabysitter.image.tag) -}}
 {{- end -}}
 
 {{/*
 Define the docker image for Vault sidecar container (image.path:image.tag).
 */}}
 {{- define "talend-vault-sidecar-injector.injectconfig.vault.image" -}}
-{{- printf "%s%s:%s" .imageRegistry .injectconfig.vault.image.path (default "latest" .injectconfig.vault.image.tag) -}}
+{{- printf "%s%s:%s" (default "" .imageRegistry) .injectconfig.vault.image.path (default "latest" .injectconfig.vault.image.tag) -}}
 {{- end -}}
 
 {{/*
 Define the docker image for pre-install hook (image.path:image.tag).
 */}}
 {{- define "talend-vault-sidecar-injector.hook.image" -}}
-{{- printf "%s%s:%s" .imageRegistry .hook.image.path (default "latest" .hook.image.tag) -}}
+{{- printf "%s%s:%s" (default "" .imageRegistry) .hook.image.path (default "latest" .hook.image.tag) -}}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -64,31 +64,38 @@ heritage: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+Define the docker registry key.
+*/}}
+{{- define "talend-vault-sidecar-injector.registryKey" -}}
+{{- .registryKey | default "" -}}
+{{- end -}}
+
+{{/*
 Define the docker image (image.path:image.tag).
 */}}
 {{- define "talend-vault-sidecar-injector.image" -}}
-{{- printf "%s:%s" .image.path (default "latest" .image.tag) -}}
+{{- printf "%s%s:%s" .imageRegistry .image.path (default "latest" .image.tag) -}}
 {{- end -}}
 
 {{/*
 Define the docker image for Job Babysitter sidecar container (image.path:image.tag).
 */}}
 {{- define "talend-vault-sidecar-injector.injectconfig.jobbabysitter.image" -}}
-{{- printf "%s:%s" .injectconfig.jobbabysitter.image.path (default "latest" .injectconfig.jobbabysitter.image.tag) -}}
+{{- printf "%s%s:%s" .imageRegistry .injectconfig.jobbabysitter.image.path (default "latest" .injectconfig.jobbabysitter.image.tag) -}}
 {{- end -}}
 
 {{/*
 Define the docker image for Vault sidecar container (image.path:image.tag).
 */}}
 {{- define "talend-vault-sidecar-injector.injectconfig.vault.image" -}}
-{{- printf "%s:%s" .injectconfig.vault.image.path (default "latest" .injectconfig.vault.image.tag) -}}
+{{- printf "%s%s:%s" .imageRegistry .injectconfig.vault.image.path (default "latest" .injectconfig.vault.image.tag) -}}
 {{- end -}}
 
 {{/*
 Define the docker image for pre-install hook (image.path:image.tag).
 */}}
 {{- define "talend-vault-sidecar-injector.hook.image" -}}
-{{- printf "%s:%s" .hook.image.path (default "latest" .hook.image.tag) -}}
+{{- printf "%s%s:%s" .imageRegistry .hook.image.path (default "latest" .hook.image.tag) -}}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -94,7 +94,7 @@ data:
           - name: SKIP_SETCAP
             value: "true"
           - name: VAULT_ADDR
-            value: {{ .Values.vault.addr }}
+            value: {{ required "Vault server's address must be specified" .Values.vault.addr | quote }}
         command:
           - "sh"
           - "-c"

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -21,8 +21,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.registryKey }}
       imagePullSecrets:
-        - name: {{ include "talend-vault-sidecar-injector.registryKey" .Values }}
+        - name: {{ .Values.registryKey }}
+      {{- end }}
       serviceAccountName: talend-vault-sidecar-injector
       containers:
         - name: {{ include "talend-vault-sidecar-injector.fullname" . }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      imagePullSecrets:
+        - name: {{ include "talend-vault-sidecar-injector.registryKey" .Values }}
       serviceAccountName: talend-vault-sidecar-injector
       containers:
         - name: {{ include "talend-vault-sidecar-injector.fullname" . }}

--- a/deploy/helm/templates/job-postinstall-certs.yaml
+++ b/deploy/helm/templates/job-postinstall-certs.yaml
@@ -16,8 +16,10 @@ spec:
       name: "{{ include "talend-vault-sidecar-injector.fullname" . }}-certs"
     spec:
       restartPolicy: Never
+      {{- if .Values.registryKey }}
       imagePullSecrets:
-        - name: {{ include "talend-vault-sidecar-injector.registryKey" .Values }}
+        - name: {{ .Values.registryKey }}
+      {{- end }}
       serviceAccountName: talend-vault-sidecar-injector
       containers:
       - name: "{{.Release.Name}}-job-certs"

--- a/deploy/helm/templates/job-postinstall-certs.yaml
+++ b/deploy/helm/templates/job-postinstall-certs.yaml
@@ -16,6 +16,8 @@ spec:
       name: "{{ include "talend-vault-sidecar-injector.fullname" . }}-certs"
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: {{ include "talend-vault-sidecar-injector.registryKey" .Values }}
       serviceAccountName: talend-vault-sidecar-injector
       containers:
       - name: "{{.Release.Name}}-job-certs"

--- a/deploy/helm/templates/job-postinstall-mutatingwebhook.yaml
+++ b/deploy/helm/templates/job-postinstall-mutatingwebhook.yaml
@@ -16,6 +16,8 @@ spec:
       name: "{{ include "talend-vault-sidecar-injector.fullname" . }}-mw"
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: {{ include "talend-vault-sidecar-injector.registryKey" .Values }}
       serviceAccountName: talend-vault-sidecar-injector
       containers:
       - name: "{{.Release.Name}}-job-mw"

--- a/deploy/helm/templates/job-postinstall-mutatingwebhook.yaml
+++ b/deploy/helm/templates/job-postinstall-mutatingwebhook.yaml
@@ -16,8 +16,10 @@ spec:
       name: "{{ include "talend-vault-sidecar-injector.fullname" . }}-mw"
     spec:
       restartPolicy: Never
+      {{- if .Values.registryKey }}
       imagePullSecrets:
-        - name: {{ include "talend-vault-sidecar-injector.registryKey" .Values }}
+        - name: {{ .Values.registryKey }}
+      {{- end }}
       serviceAccountName: talend-vault-sidecar-injector
       containers:
       - name: "{{.Release.Name}}-job-mw"

--- a/deploy/helm/templates/job-predelete.yaml
+++ b/deploy/helm/templates/job-predelete.yaml
@@ -16,8 +16,10 @@ spec:
       name: "{{ include "talend-vault-sidecar-injector.fullname" . }}-del"
     spec:
       restartPolicy: Never
+      {{- if .Values.registryKey }}
       imagePullSecrets:
-        - name: {{ include "talend-vault-sidecar-injector.registryKey" .Values }}
+        - name: {{ .Values.registryKey }}
+      {{- end }}
       serviceAccountName: talend-vault-sidecar-injector
       containers:
       - name: "{{.Release.Name}}-job-del"

--- a/deploy/helm/templates/job-predelete.yaml
+++ b/deploy/helm/templates/job-predelete.yaml
@@ -16,6 +16,8 @@ spec:
       name: "{{ include "talend-vault-sidecar-injector.fullname" . }}-del"
     spec:
       restartPolicy: Never
+      imagePullSecrets:
+        - name: {{ include "talend-vault-sidecar-injector.registryKey" .Values }}
       serviceAccountName: talend-vault-sidecar-injector
       containers:
       - name: "{{.Release.Name}}-job-del"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -133,7 +133,7 @@ probes:
 # ----------------------------------------------------------------------------
 
 vault:
-  addr: https://vault:8200  # Address of Vault server
+  addr: ~  # Address of Vault server
   authMethods:
     kubernetes:
       path: kubernetes # Path defined for Kubernetes Auth Method


### PR DESCRIPTION
- No more Vault address set by default: must be provided using `--set vault.addr=<Vault server address>`
- Option: handle `imagePullSecrets` using new `registryKey` value 
- Option: custom image registry can be provided using new `imageRegistry` value 